### PR TITLE
feat/add operator address that can mint and burn tokens

### DIFF
--- a/contracts/waffle.json
+++ b/contracts/waffle.json
@@ -1,6 +1,6 @@
 {
   "compilerType": "solcjs",
-  "compilerVersion": "0.8.1",
+  "compilerVersion": "0.8.6",
   "sourceDirectory": "./src",
   "outputDirectory": "./build",
   "compilerOptions": {


### PR DESCRIPTION
Add a new operator address in the Gateway contract, who is allowed to mint and burn tokens. In reality, the operator will be set to the Ethereum's secondary key's address.