### PR TITLE
refactor: Cleanup

### DIFF
--- a/contracts/src/AxelarGateway.sol
+++ b/contracts/src/AxelarGateway.sol
@@ -11,22 +11,24 @@ contract AxelarGateway {
         address indexed previousOwner,
         address indexed newOwner
     );
+
     event OperatorshipTransferred(
         address indexed previousOperator,
         address indexed newOperator
     );
+
     event TokenDeployed(string symbol, address tokenAddress);
 
-    address private _prevOwner;
-    address private _owner;
-    address private _operator;
-    address private _prevOperator;
+    address public prevOwner;
+    address public owner;
+    address public operator;
+    address public prevOperator;
 
     mapping(string => bytes4) private _commandSelectors;
     mapping(string => address) private _commandAddresses;
     mapping(bytes32 => bool) private _commandExecuted;
 
-    mapping(string => address) private _tokenAddresses;
+    mapping(string => address) public tokenAddresses;
 
     modifier onlySelf() {
         require(
@@ -38,57 +40,23 @@ contract AxelarGateway {
     }
 
     constructor(address operatorAddr) {
-        _owner = msg.sender;
-        _operator = operatorAddr;
+        owner = msg.sender;
+        operator = operatorAddr;
 
         emit OwnershipTransferred(address(0), msg.sender);
         emit OperatorshipTransferred(address(0), operatorAddr);
 
-        _commandSelectors['deployToken'] = bytes4(
-            keccak256(bytes('_deployToken(address,bytes)'))
-        );
-        _commandSelectors['mintToken'] = bytes4(
-            keccak256(bytes('_mintToken(address,bytes)'))
-        );
-        _commandSelectors['burnToken'] = bytes4(
-            keccak256(bytes('_burnToken(address,bytes)'))
-        );
-        _commandSelectors['transferOwnership'] = bytes4(
-            keccak256(bytes('_transferOwnership(address,bytes)'))
-        );
-        _commandSelectors['transferOperatorship'] = bytes4(
-            keccak256(bytes('_transferOperatorship(address,bytes)'))
-        );
+        _commandSelectors['deployToken'] = AxelarGateway._deployToken.selector;
+        _commandSelectors['mintToken'] = AxelarGateway._mintToken.selector;
+        _commandSelectors['burnToken'] = AxelarGateway._burnToken.selector;
+        _commandSelectors['transferOwnership'] = AxelarGateway._transferOwnership.selector;
+        _commandSelectors['transferOperatorship'] = AxelarGateway._transferOperatorship.selector;
 
         _commandAddresses['deployToken'] = address(this);
         _commandAddresses['mintToken'] = address(this);
         _commandAddresses['burnToken'] = address(this);
         _commandAddresses['transferOwnership'] = address(this);
         _commandAddresses['transferOperatorship'] = address(this);
-    }
-
-    function owner() public view returns (address) {
-        return _owner;
-    }
-
-    function prevOwner() public view returns (address) {
-        return _prevOwner;
-    }
-
-    function operator() public view returns (address) {
-        return _operator;
-    }
-
-    function prevOperator() public view returns (address) {
-        return _prevOperator;
-    }
-
-    function tokenAddresses(string memory symbol)
-        public
-        view
-        returns (address)
-    {
-        return _tokenAddresses[symbol];
     }
 
     function execute(bytes memory input) public {
@@ -103,10 +71,10 @@ contract AxelarGateway {
             ECDSA.recover(ECDSA.toEthSignedMessageHash(keccak256(data)), sig);
 
         require(
-            signer == _operator ||
-                signer == _owner ||
-                signer == _prevOperator ||
-                signer == _prevOwner,
+            signer == operator ||
+            signer == owner ||
+            signer == prevOperator ||
+            signer == prevOwner,
             'AxelarGateway: signer is not owner or operator'
         );
 
@@ -126,14 +94,13 @@ contract AxelarGateway {
 
         require(
             commandsLength == commands.length &&
-                commandsLength == params.length,
+            commandsLength == params.length,
             'AxelarGateway: commands params length mismatch'
         );
 
         for (uint256 i = 0; i < commandsLength; i++) {
             bytes32 commandId = commandIds[i];
             string memory command = commands[i];
-            bytes memory param = params[i];
 
             if (_commandExecuted[commandId]) {
                 continue; /* Ignore if duplicate commandId received */
@@ -148,19 +115,18 @@ contract AxelarGateway {
 
             (bool success, bytes memory result) =
                 commandAddress.call(
-                    abi.encodeWithSelector(commandSelector, signer, param)
+                    abi.encodeWithSelector(commandSelector, signer, params[i])
                 );
 
-            if (!success) {
-                revert(
-                    string(
-                        abi.encodePacked(
-                            'AxelarGateway: command failed with error: ',
-                            result
-                        )
+            require(
+                success,
+                string(
+                    abi.encodePacked(
+                        'AxelarGateway: command failed with error: ',
+                        result
                     )
-                );
-            }
+                )
+            );
 
             _commandExecuted[commandId] = true;
         }
@@ -178,11 +144,12 @@ contract AxelarGateway {
         ) = abi.decode(params, (string, string, uint8, uint256));
 
         require(
-            _tokenAddresses[symbol] == address(0),
+            tokenAddresses[symbol] == address(0),
             'AxelarGateway: token already deployed'
         );
+
         require(
-            signer == _owner || signer == _prevOwner,
+            signer == owner || signer == prevOwner,
             'AxelarGateway: only owner can deploy token'
         );
 
@@ -194,17 +161,15 @@ contract AxelarGateway {
                 decimals,
                 cap
             );
-        address tokenAddress = address(token);
-        _tokenAddresses[symbol] = tokenAddress;
 
-        emit TokenDeployed(symbol, tokenAddress);
+        emit TokenDeployed(symbol, tokenAddresses[symbol] = address(token));
     }
 
     function _mintToken(address, bytes memory params) external onlySelf {
         (string memory symbol, address account, uint256 amount) =
             abi.decode(params, (string, address, uint256));
 
-        address tokenAddress = _tokenAddresses[symbol];
+        address tokenAddress = tokenAddresses[symbol];
         require(
             tokenAddress != address(0),
             'AxelarGateway: token not deployed'
@@ -217,7 +182,7 @@ contract AxelarGateway {
         (string memory symbol, bytes32 salt) =
             abi.decode(params, (string, bytes32));
 
-        address tokenAddress = _tokenAddresses[symbol];
+        address tokenAddress = tokenAddresses[symbol];
         require(
             tokenAddress != address(0),
             'AxelarGateway: token not deployed'
@@ -236,15 +201,16 @@ contract AxelarGateway {
             newOwner != address(0),
             'AxelarGateway: new owner is the zero address'
         );
+        
         require(
-            signer == _owner,
+            signer == owner,
             'AxelarGateway: only current owner can transfer ownership'
         );
 
-        emit OwnershipTransferred(_owner, newOwner);
+        emit OwnershipTransferred(owner, newOwner);
 
-        _prevOwner = _owner;
-        _owner = newOwner;
+        prevOwner = owner;
+        owner = newOwner;
     }
 
     function _transferOperatorship(address signer, bytes memory params)
@@ -252,27 +218,25 @@ contract AxelarGateway {
         onlySelf
     {
         address newOperator = abi.decode(params, (address));
+
         require(
             newOperator != address(0),
             'AxelarGateway: new operator is the zero address'
         );
         require(
-            signer == _owner,
+            signer == owner,
             'AxelarGateway: only current owner can transfer operatorship'
         );
 
-        emit OperatorshipTransferred(_operator, newOperator);
+        emit OperatorshipTransferred(operator, newOperator);
 
-        _prevOperator = _operator;
-        _operator = newOperator;
+        prevOperator = operator;
+        operator = newOperator;
     }
 
-    function _getChainID() internal view returns (uint256) {
-        uint256 id;
+    function _getChainID() internal view returns (uint256 id) {
         assembly {
             id := chainid()
         }
-
-        return id;
     }
 }

--- a/contracts/src/AxelarGateway.sol
+++ b/contracts/src/AxelarGateway.sol
@@ -2,9 +2,9 @@
 
 pragma solidity >=0.8.0 <0.9.0;
 
-import './ECDSA.sol';
-import './BurnableMintableCappedERC20.sol';
-import './Burner.sol';
+import { ECDSA } from './ECDSA.sol';
+import { BurnableMintableCappedERC20 } from './BurnableMintableCappedERC20.sol';
+import { Burner } from './Burner.sol';
 
 contract AxelarGateway {
     event OwnershipTransferred(
@@ -162,7 +162,8 @@ contract AxelarGateway {
                 cap
             );
 
-        emit TokenDeployed(symbol, tokenAddresses[symbol] = address(token));
+        tokenAddresses[symbol] = address(token);
+        emit TokenDeployed(symbol, address(token));
     }
 
     function _mintToken(address, bytes memory params) external onlySelf {
@@ -223,6 +224,7 @@ contract AxelarGateway {
             newOperator != address(0),
             'AxelarGateway: new operator is the zero address'
         );
+
         require(
             signer == owner,
             'AxelarGateway: only current owner can transfer operatorship'

--- a/contracts/src/BurnableMintableCappedERC20.sol
+++ b/contracts/src/BurnableMintableCappedERC20.sol
@@ -7,7 +7,7 @@ import './Ownable.sol';
 import './Burner.sol';
 
 contract BurnableMintableCappedERC20 is ERC20, Ownable {
-    uint256 private _cap;
+    uint256 public cap;
 
     modifier onlyBurner(bytes32 salt) {
         bytes memory burnerInitCode =
@@ -16,7 +16,9 @@ contract BurnableMintableCappedERC20 is ERC20, Ownable {
                 abi.encode(address(this)),
                 salt
             );
+
         bytes32 burnerInitCodeHash = keccak256(burnerInitCode);
+
         /* Convert a hash which is bytes32 to an address which is 20-byte long
         according to https://docs.soliditylang.org/en/v0.8.1/control-structures.html?highlight=create2#salted-contract-creations-create2 */
         address burnerAddress =
@@ -26,7 +28,7 @@ contract BurnableMintableCappedERC20 is ERC20, Ownable {
                         keccak256(
                             abi.encodePacked(
                                 bytes1(0xff),
-                                owner(),
+                                owner,
                                 salt,
                                 burnerInitCodeHash
                             )
@@ -48,14 +50,13 @@ contract BurnableMintableCappedERC20 is ERC20, Ownable {
         string memory symbol,
         uint8 decimals,
         uint256 capacity
-    ) ERC20(name, symbol) Ownable() {
-        _setupDecimals(decimals);
-        _cap = capacity;
+    ) ERC20(name, symbol, decimals) Ownable() {
+        cap = capacity;
     }
 
     function mint(address account, uint256 amount) public onlyOwner {
         require(
-            totalSupply() + amount <= _cap,
+            totalSupply + amount <= cap,
             'BurnableMintableCappedERC20: cap exceeded'
         );
 
@@ -65,10 +66,6 @@ contract BurnableMintableCappedERC20 is ERC20, Ownable {
     function burn(bytes32 salt) public onlyBurner(salt) {
         address account = msg.sender;
 
-        _burn(account, balanceOf(account));
-    }
-
-    function cap() public view returns (uint256) {
-        return _cap;
+        _burn(account, balanceOf[account]);
     }
 }

--- a/contracts/src/BurnableMintableCappedERC20.sol
+++ b/contracts/src/BurnableMintableCappedERC20.sol
@@ -2,9 +2,9 @@
 
 pragma solidity >=0.8.0 <0.9.0;
 
-import './ERC20.sol';
-import './Ownable.sol';
-import './Burner.sol';
+import { ERC20 } from './ERC20.sol';
+import { Ownable } from './Ownable.sol';
+import { Burner } from './Burner.sol';
 
 contract BurnableMintableCappedERC20 is ERC20, Ownable {
     uint256 public cap;

--- a/contracts/src/Burner.sol
+++ b/contracts/src/Burner.sol
@@ -2,7 +2,7 @@
 
 pragma solidity >=0.8.0 <0.9.0;
 
-import './BurnableMintableCappedERC20.sol';
+import { BurnableMintableCappedERC20 } from './BurnableMintableCappedERC20.sol';
 
 contract Burner {
     constructor(address tokenAddress, bytes32 salt) {

--- a/contracts/src/ECDSA.sol
+++ b/contracts/src/ECDSA.sol
@@ -26,12 +26,10 @@ library ECDSA {
     function recover(bytes32 hash, bytes memory signature)
         internal
         pure
-        returns (address)
+        returns (address signer)
     {
         // Check the signature length
-        if (signature.length != 65) {
-            revert('ECDSA: invalid signature length');
-        }
+        require(signature.length == 65, 'ECDSA: invalid signature length');
 
         // Divide the signature in r, s and v variables
         bytes32 r;
@@ -61,13 +59,11 @@ library ECDSA {
                 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
             'ECDSA: invalid signature "s" value'
         );
+
         require(v == 27 || v == 28, 'ECDSA: invalid signature "v" value');
 
         // If the signature is valid (and not malleable), return the signer address
-        address signer = ecrecover(hash, v, r, s);
-        require(signer != address(0), 'ECDSA: invalid signature');
-
-        return signer;
+        require((signer = ecrecover(hash, v, r, s)) != address(0), 'ECDSA: invalid signature');
     }
 
     /**

--- a/contracts/src/ERC20.sol
+++ b/contracts/src/ERC20.sol
@@ -2,8 +2,8 @@
 
 pragma solidity >=0.8.0 <0.9.0;
 
-import './Context.sol';
-import './IERC20.sol';
+import { Context } from './Context.sol';
+import { IERC20 } from './IERC20.sol';
 
 /**
  * @dev Implementation of the {IERC20} interface.

--- a/contracts/src/ERC20.sol
+++ b/contracts/src/ERC20.sol
@@ -30,75 +30,27 @@ import './IERC20.sol';
  * allowances. See {IERC20-approve}.
  */
 contract ERC20 is Context, IERC20 {
-    mapping(address => uint256) private _balances;
+    mapping(address => uint256) public override balanceOf;
 
-    mapping(address => mapping(address => uint256)) private _allowances;
+    mapping(address => mapping(address => uint256)) public override allowance;
 
-    uint256 private _totalSupply;
+    uint256 public override totalSupply;
 
-    string private _name;
-    string private _symbol;
-    uint8 private _decimals;
+    string public name;
+    string public symbol;
+
+    uint8 public immutable decimals;
 
     /**
-     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
-     * a default value of 18.
-     *
-     * To select a different value for {decimals}, use {_setupDecimals}.
+     * @dev Sets the values for {name}, {symbol}, and {decimals}.
      *
      * All three of these values are immutable: they can only be set once during
      * construction.
      */
-    constructor(string memory name_, string memory symbol_) {
-        _name = name_;
-        _symbol = symbol_;
-        _decimals = 18;
-    }
-
-    /**
-     * @dev Returns the name of the token.
-     */
-    function name() public view returns (string memory) {
-        return _name;
-    }
-
-    /**
-     * @dev Returns the symbol of the token, usually a shorter version of the
-     * name.
-     */
-    function symbol() public view returns (string memory) {
-        return _symbol;
-    }
-
-    /**
-     * @dev Returns the number of decimals used to get its user representation.
-     * For example, if `decimals` equals `2`, a balance of `505` tokens should
-     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
-     *
-     * Tokens usually opt for a value of 18, imitating the relationship between
-     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
-     * called.
-     *
-     * NOTE: This information is only used for _display_ purposes: it in
-     * no way affects any of the arithmetic of the contract, including
-     * {IERC20-balanceOf} and {IERC20-transfer}.
-     */
-    function decimals() public view returns (uint8) {
-        return _decimals;
-    }
-
-    /**
-     * @dev See {IERC20-totalSupply}.
-     */
-    function totalSupply() public view override returns (uint256) {
-        return _totalSupply;
-    }
-
-    /**
-     * @dev See {IERC20-balanceOf}.
-     */
-    function balanceOf(address account) public view override returns (uint256) {
-        return _balances[account];
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        name = name_;
+        symbol = symbol_;
+        decimals = decimals_;
     }
 
     /**
@@ -117,19 +69,6 @@ contract ERC20 is Context, IERC20 {
     {
         _transfer(_msgSender(), recipient, amount);
         return true;
-    }
-
-    /**
-     * @dev See {IERC20-allowance}.
-     */
-    function allowance(address owner, address spender)
-        public
-        view
-        virtual
-        override
-        returns (uint256)
-    {
-        return _allowances[owner][spender];
     }
 
     /**
@@ -171,7 +110,7 @@ contract ERC20 is Context, IERC20 {
         _approve(
             sender,
             _msgSender(),
-            _allowances[sender][_msgSender()] - amount
+            allowance[sender][_msgSender()] - amount
         );
         return true;
     }
@@ -196,7 +135,7 @@ contract ERC20 is Context, IERC20 {
         _approve(
             _msgSender(),
             spender,
-            _allowances[_msgSender()][spender] + addedValue
+            allowance[_msgSender()][spender] + addedValue
         );
         return true;
     }
@@ -223,7 +162,7 @@ contract ERC20 is Context, IERC20 {
         _approve(
             _msgSender(),
             spender,
-            _allowances[_msgSender()][spender] - subtractedValue
+            allowance[_msgSender()][spender] - subtractedValue
         );
         return true;
     }
@@ -252,8 +191,8 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(sender, recipient, amount);
 
-        _balances[sender] -= amount;
-        _balances[recipient] += amount;
+        balanceOf[sender] -= amount;
+        balanceOf[recipient] += amount;
         emit Transfer(sender, recipient, amount);
     }
 
@@ -271,8 +210,8 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(address(0), account, amount);
 
-        _totalSupply += amount;
-        _balances[account] += amount;
+        totalSupply += amount;
+        balanceOf[account] += amount;
         emit Transfer(address(0), account, amount);
     }
 
@@ -292,8 +231,8 @@ contract ERC20 is Context, IERC20 {
 
         _beforeTokenTransfer(account, address(0), amount);
 
-        _balances[account] -= amount;
-        _totalSupply -= amount;
+        balanceOf[account] -= amount;
+        totalSupply -= amount;
         emit Transfer(account, address(0), amount);
     }
 
@@ -318,19 +257,8 @@ contract ERC20 is Context, IERC20 {
         require(owner != address(0), 'ERC20: approve from the zero address');
         require(spender != address(0), 'ERC20: approve to the zero address');
 
-        _allowances[owner][spender] = amount;
+        allowance[owner][spender] = amount;
         emit Approval(owner, spender, amount);
-    }
-
-    /**
-     * @dev Sets {decimals} to a value other than the default one of 18.
-     *
-     * WARNING: This function should only be called from the constructor. Most
-     * applications that interact with token contracts will not expect
-     * {decimals} to ever change, and may work incorrectly if it does.
-     */
-    function _setupDecimals(uint8 decimals_) internal {
-        _decimals = decimals_;
     }
 
     /**

--- a/contracts/src/Ownable.sol
+++ b/contracts/src/Ownable.sol
@@ -11,7 +11,8 @@ abstract contract Ownable {
     );
 
     constructor() {
-        emit OwnershipTransferred(address(0), owner = msg.sender);
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
     }
 
     modifier onlyOwner() {
@@ -25,6 +26,7 @@ abstract contract Ownable {
             'Ownable: new owner is the zero address'
         );
 
-        emit OwnershipTransferred(owner, owner = newOwner);
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
     }
 }

--- a/contracts/src/Ownable.sol
+++ b/contracts/src/Ownable.sol
@@ -3,7 +3,7 @@
 pragma solidity >=0.8.0 <0.9.0;
 
 abstract contract Ownable {
-    address private _owner;
+    address public owner;
 
     event OwnershipTransferred(
         address indexed previousOwner,
@@ -11,18 +11,11 @@ abstract contract Ownable {
     );
 
     constructor() {
-        address msgSender = msg.sender;
-        _owner = msgSender;
-
-        emit OwnershipTransferred(address(0), msgSender);
-    }
-
-    function owner() public view returns (address) {
-        return _owner;
+        emit OwnershipTransferred(address(0), owner = msg.sender);
     }
 
     modifier onlyOwner() {
-        require(_owner == msg.sender, 'Ownable: caller is not the owner');
+        require(owner == msg.sender, 'Ownable: caller is not the owner');
         _;
     }
 
@@ -32,7 +25,6 @@ abstract contract Ownable {
             'Ownable: new owner is the zero address'
         );
 
-        emit OwnershipTransferred(_owner, newOwner);
-        _owner = newOwner;
+        emit OwnershipTransferred(owner, owner = newOwner);
     }
 }


### PR DESCRIPTION
- replace privates with publics to remove function redundancy
- use `Contract.function.selector` instead of inline keccak
- simplify if-reverts into requires
- ERC20 constructor now takes decimals as an argument, making `_setupDecimals` redundant
- make `decimals` immutable (instead of a storage slot)
- more minor gas optimizations